### PR TITLE
chore(ci): add coverage reporting (QA-3282)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,23 @@
+name: Coverage
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    uses: MoneyLion/actions/.github/workflows/run-coverage.yaml@main
+    with:
+      language: javascript
+      # CRA's react-scripts test wraps Jest. CI=true + --watchAll=false stop
+      # the interactive watcher; --coverageReporters=json-summary writes
+      # coverage/coverage-summary.json which the coverage-report action consumes.
+      test-command: CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=json-summary
+      coverage-gate-mode: soft
+    secrets: inherit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,22 +2,14 @@ name: Coverage
 
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
-  workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   coverage:
     uses: MoneyLion/actions/.github/workflows/run-coverage.yaml@main
     with:
       language: javascript
-      # CRA's react-scripts test wraps Jest. CI=true + --watchAll=false stop
-      # the interactive watcher; --coverageReporters=json-summary writes
-      # coverage/coverage-summary.json which the coverage-report action consumes.
       test-command: CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=json-summary
-      coverage-gate-mode: soft
     secrets: inherit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,5 +11,5 @@ jobs:
     uses: MoneyLion/actions/.github/workflows/run-coverage.yaml@main
     with:
       language: javascript
-      test-command: CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=json-summary
+      test-command: "CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=json-summary"
     secrets: inherit


### PR DESCRIPTION
## What

Adds a `coverage.yml` workflow calling the shared `MoneyLion/actions/.github/workflows/run-coverage.yaml@main` reusable workflow (Pattern 1 — single-package JS/TS).

This is the **first PR in the QA-3282 wave** (TS/JS rollout, 21 repos). `coding-challenge-search-ui` was picked as the pilot because it has no existing workflows, so this change is purely additive — zero risk to anything currently running in CI.

## Why

Wires the repo into the MoneyLion code-coverage pipeline:
- Each PR gets a `## 📊 Test coverage` comment with diff-based new-code coverage and a quality-gate verdict (`soft` mode — won't block merges).
- Each merge to `main` uploads coverage data to Snowflake for the [QA-3264 Code Coverage Observatory](https://moneylion.atlassian.net/browse/QA-3264) dashboard.

## How it works

CRA 5.0.1 wraps Jest. The workflow runs:

```
CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=json-summary
```

- `CI=true` + `--watchAll=false` — disables Jest's interactive watch mode (would otherwise hang in CI)
- `--coverage --coverageReporters=json-summary` — emits `coverage/coverage-summary.json`, the format `coverage-report` consumes for JS

No changes to `package.json` or any source files — the json-summary reporter is added entirely via the workflow's `test-command:` so local-dev `yarn test` behaviour is unchanged.

## Verification (after merge)

- [ ] Workflow run is green on a follow-up PR
- [ ] `## 📊 Test coverage` comment appears on the PR with real numbers (not 0%)
- [ ] Snowflake row lands within ~5 min of merge to `main` (data team can confirm via QA-3264 dashboard)

## Refs

- Ticket: [QA-3282](https://moneylion.atlassian.net/browse/QA-3282)
- Skill: [`skills/qa/adding-coverage-reporting`](https://github.com/MoneyLion/moneylion-knowledge-base/tree/main/skills/qa/adding-coverage-reporting)
- Epic: [QA-3258](https://moneylion.atlassian.net/browse/QA-3258) — Custom Code Coverage Tool to Replace SonarCloud

Made with [Cursor](https://cursor.com)

[QA-3282]: https://moneylion.atlassian.net/browse/QA-3282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ